### PR TITLE
Use local cordova executable on npm build

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "postinstall": " cd scripts && ./postinstall.sh",
-    "build:apk": "cordova build android 2>&1",
+    "build:apk": "./node_modules/.bin/cordova build android 2>&1",
     "test": "grunt test",
     "clean": "rm -rf platforms plugins node_modules",
     "update:tree": "git pull && chown -R www-data:www-data .",


### PR DESCRIPTION
@chrisekelley I'm getting my sandbox set up to build. The current build command uses the global cordova executable. Would it make sense to use the one installed by npm? I'm not 100% certain this works yet.
